### PR TITLE
Fix typo in README.md

### DIFF
--- a/README
+++ b/README
@@ -7,7 +7,7 @@
 
 About
 -----
-This plugin provides the export of article metadata and full texts (in PDF and EPUB format) for their tranfer to the German National Library (DNB)
+This plugin provides the export of article metadata and full texts (in PDF and EPUB format) for their transfer to the German National Library (DNB)
 using the DNB Hotfolder method. The plugin also offers the option of directly depositing the transfer package into the DNB Hotfolder.
 Details on the Hotfolder method are available at: http://nbn-resolving.de/urn%3Anbn%3Ade%3A101-2016111401
 Details on the XML format and data requirements are available at: http://nbn-resolving.de/urn%3Anbn%3Ade%3A101-2014071124


### PR DESCRIPTION
This is the same fix as afcd35ffe5603cc463aec5e06cce57fbcd98c89d on branch ojs-stable-2_4_8.